### PR TITLE
feat: add display style selector for daily/weekly/monthly stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@material-ui/icons": "^4.11.3",
         "@material-ui/lab": "^4.0.0-alpha.61",
         "cypress": "^9.5.2",
+        "dayjs": "^1.11.7",
         "minimatch": "^5.1.2",
         "prettier": "^2.7.1",
         "react": "^16.14.0",
@@ -6683,9 +6684,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "node_modules/debug": {
       "version": "4.1.1",
@@ -23413,9 +23414,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.0.tgz",
-      "integrity": "sha512-JLC809s6Y948/FuCZPm5IX8rRhQwOiyMb2TfVVQEixG7P8Lm/gt5S7yoQZmC8x1UehI9Pb7sksEt4xx14m+7Ug=="
+      "version": "1.11.7",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
+      "integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
     },
     "debug": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@material-ui/icons": "^4.11.3",
     "@material-ui/lab": "^4.0.0-alpha.61",
     "cypress": "^9.5.2",
+    "dayjs": "^1.11.7",
     "minimatch": "^5.1.2",
     "prettier": "^2.7.1",
     "react": "^16.14.0",

--- a/src/components/DownloadsComponent.js
+++ b/src/components/DownloadsComponent.js
@@ -158,6 +158,10 @@ class DownloadsComponent extends Component {
   };
 
   handleDisplayStyleChange = (event, newDisplayStyle) => {
+    // Don't allow deselection
+    if(!newDisplayStyle) {
+      return;
+    }
     this.setState({ displayStyle: newDisplayStyle });
     let currentUrlParams = new URLSearchParams(window.location.search);
     currentUrlParams.set('display', newDisplayStyle);

--- a/src/components/DownloadsComponent.js
+++ b/src/components/DownloadsComponent.js
@@ -72,23 +72,19 @@ class DownloadsComponent extends Component {
 
     if (displayStyle !== 'daily') {
       let getDateIndex = (date) => date;
-      let formatDate = (date) => date;
 
       if (displayStyle === 'weekly') {
         getDateIndex = (date) => date.week();
-        formatDate = (date) => {
-          return date.week() + ' - ' + date.year();
-        };
       } else if (displayStyle === 'monthly') {
-        formatDate = (date) => date.format('YYYY-MM');
         getDateIndex = (date) => date.month();
       }
+
       const reducedData = data.reduce((weeks, currentDay) => {
         const date = dayjs(currentDay.date);
         const weekOfYear = getDateIndex(date);
         if (!weeks[weekOfYear]) {
           weeks[weekOfYear] = {
-            date: currentDay.date, // formatDate(date),//
+            date: currentDay.date,
             total: 0,
             sum: 0,
           };

--- a/src/components/DownloadsComponent.test.js
+++ b/src/components/DownloadsComponent.test.js
@@ -95,14 +95,14 @@ describe('<DownloadsComponent />', () => {
     ]);
   });
 
-  it('takes the display style weekly from url', () => {
+  it('takes the display style monthly from url', () => {
     const data = {
-      versions: ['0.1'],
+      versions: ['0.1', '0.2', '0.3'],
       downloads: {
         '2020-01-01': { 0.1: 5 },
         '2020-01-04': { 0.1: 5 },
         '2020-02-01': { 0.1: 10, 0.2: 5 },
-        '2020-02-02': { 0.1: 5, 0.2: 5 },
+        '2020-02-02': { 0.1: 5, 0.2: 5, 0.3: 5 },
       },
     };
     delete global.window.location;
@@ -118,11 +118,43 @@ describe('<DownloadsComponent />', () => {
     expect(wrapper.find('DownloadsTable')).toHaveLength(1);
     const expectedData = [
       { date: '2020-01-01', 0.1: 10, 0.2: 0, sum: 10, total: 10 },
-      { date: '2020-02-01', 0.1: 15, 0.2: 10, sum: 25, total: 25 },
+      { date: '2020-02-01', 0.1: 15, 0.2: 10, sum: 25, total: 30 },
     ];
     expect(wrapper.find('DownloadsTable').props().data).toEqual(expectedData);
     expect(wrapper.find('DownloadsComponent').state().displayStyle).toEqual(
       'monthly'
+    );
+  });
+  it('takes the display style weekly from url', () => {
+    const data = {
+      versions: ['0.1', '0.2', '0.3'],
+      downloads: {
+        '2023-01-01': { 0.1: 5 },
+        '2023-01-04': { 0.1: 5 },
+        '2023-01-10': { 0.1: 10, 0.2: 5 },
+        '2023-02-01': { 0.1: 10, 0.2: 5, 0.3: 5 },
+      },
+    };
+    delete global.window.location;
+    global.window.location = new URL(
+      'http://localhost:3000/project/climoji?display=weekly&versions=0.1&versions=0.2'
+    );
+    const wrapper = mount(
+      <Router>
+        <DownloadsComponent data={data} />
+      </Router>
+    );
+
+    expect(wrapper.find('DownloadsTable')).toHaveLength(1);
+    const expectedData = [
+      { date: '2023-01-01', 0.1: 10, 0.2: 0, sum: 10, total: 10 },
+      { date: '2023-01-10', 0.1: 10, 0.2: 5, sum: 15, total: 15 },
+      { date: '2023-02-01', 0.1: 10, 0.2: 5, sum: 15, total: 20 },
+    ];
+    console.log(wrapper.find('DownloadsTable').props().data);
+    expect(wrapper.find('DownloadsTable').props().data).toEqual(expectedData);
+    expect(wrapper.find('DownloadsComponent').state().displayStyle).toEqual(
+      'weekly'
     );
   });
 });

--- a/src/components/DownloadsComponent.test.js
+++ b/src/components/DownloadsComponent.test.js
@@ -94,4 +94,35 @@ describe('<DownloadsComponent />', () => {
       '2.*',
     ]);
   });
+
+  it('takes the display style weekly from url', () => {
+    const data = {
+      versions: ['0.1'],
+      downloads: {
+        '2020-01-01': { 0.1: 5 },
+        '2020-01-04': { 0.1: 5 },
+        '2020-02-01': { 0.1: 10, 0.2: 5 },
+        '2020-02-02': { 0.1: 5, 0.2: 5 },
+      },
+    };
+    delete global.window.location;
+    global.window.location = new URL(
+      'http://localhost:3000/project/climoji?display=monthly&versions=0.1&versions=0.2'
+    );
+    const wrapper = mount(
+      <Router>
+        <DownloadsComponent data={data} />
+      </Router>
+    );
+
+    expect(wrapper.find('DownloadsTable')).toHaveLength(1);
+    const expectedData = [
+      { date: '2020-01-01', 0.1: 10, 0.2: 0, sum: 10, total: 10 },
+      { date: '2020-02-01', 0.1: 15, 0.2: 10, sum: 25, total: 25 },
+    ];
+    expect(wrapper.find('DownloadsTable').props().data).toEqual(expectedData);
+    expect(wrapper.find('DownloadsComponent').state().displayStyle).toEqual(
+      'monthly'
+    );
+  });
 });


### PR DESCRIPTION
Thanks for the great tool! I added a display style selector for the stats section. You can select daily/weekly/monthly graphs. 
The switch is blocking so it takes a few milliseconds (similar to selecting new versions).
Please let me know if an API change is preferred here 😊
For the prototype I used dayjs for date formatting because it is a subdependency already. We should add that to package.json if we decide to keep it for the merged version.

### Desktop
<img width="906" alt="image" src="https://user-images.githubusercontent.com/9725143/209681616-db1dca38-c599-4fa1-827b-ce99d9ef4377.png">

#### Monthly
<img width="901" alt="image" src="https://user-images.githubusercontent.com/9725143/209681663-f2e76e8b-74a8-4f70-8795-ba41dbd4f2cd.png">


### Mobile
<img width="228" alt="image" src="https://user-images.githubusercontent.com/9725143/209681748-00335b7d-b2e9-4e4d-8a25-89f26316879b.png">

As you can see, the first month is always lower due to the API just delivering the last 90 days, not the full start of the month, so that's something for a backend PR ☺️

fixes [#487](https://github.com/psincraian/pepy/issues/487)